### PR TITLE
Load labels in `GetPullRequest`

### DIFF
--- a/github.go
+++ b/github.go
@@ -314,19 +314,23 @@ func (m *GithubClient) GetPullRequest(prNumber, commitRef string) (*PullRequest,
 	}
 
 	pullRequest := PullRequest{}
+	commitRefFound := false
 
 	for _, c := range query.Repository.PullRequest.Commits.Nodes {
 		if c.Commit.OID == commitRef {
+			commitRefFound = true
 			pullRequest = PullRequest{
 				PullRequestObject: query.Repository.PullRequest.PullRequestObject,
 				Tip:               c.Commit,
 			}
 			// Return as soon as we find the correct ref.
 			break
-		} else {
-			// Return an error if the commit was not found
-			return nil, fmt.Errorf("commit with ref '%s' does not exist", commitRef)
 		}
+	}
+
+	if !commitRefFound {
+		// Return an error if the commit was not found
+		return nil, fmt.Errorf("commit with ref '%s' does not exist", commitRef)
 	}
 
 	for _, l := range query.Repository.PullRequest.Labels.Nodes {

--- a/github.go
+++ b/github.go
@@ -287,12 +287,15 @@ func (m *GithubClient) GetPullRequest(prNumber, commitRef string) (*PullRequest,
 			PullRequest struct {
 				PullRequestObject
 				Commits struct {
-					Edges []struct {
-						Node struct {
-							Commit CommitObject
-						}
+					Nodes []struct {
+						Commit CommitObject
 					}
 				} `graphql:"commits(last:$commitsLast)"`
+				Labels struct {
+					Nodes []struct {
+						LabelObject
+					}
+				} `graphql:"labels(first:$labelsFirst)"`
 			} `graphql:"pullRequest(number:$prNumber)"`
 		} `graphql:"repository(owner:$repositoryOwner,name:$repositoryName)"`
 	}
@@ -302,6 +305,7 @@ func (m *GithubClient) GetPullRequest(prNumber, commitRef string) (*PullRequest,
 		"repositoryName":  githubv4.String(m.Repository),
 		"prNumber":        githubv4.Int(pr),
 		"commitsLast":     githubv4.Int(100),
+		"labelsFirst":     githubv4.Int(100),
 	}
 
 	// TODO: Pagination - in case someone pushes > 100 commits before the build has time to start :p
@@ -309,18 +313,27 @@ func (m *GithubClient) GetPullRequest(prNumber, commitRef string) (*PullRequest,
 		return nil, err
 	}
 
-	for _, c := range query.Repository.PullRequest.Commits.Edges {
-		if c.Node.Commit.OID == commitRef {
-			// Return as soon as we find the correct ref.
-			return &PullRequest{
+	pullRequest := PullRequest{}
+
+	for _, c := range query.Repository.PullRequest.Commits.Nodes {
+		if c.Commit.OID == commitRef {
+			pullRequest = PullRequest{
 				PullRequestObject: query.Repository.PullRequest.PullRequestObject,
-				Tip:               c.Node.Commit,
-			}, nil
+				Tip:               c.Commit,
+			}
+			// Return as soon as we find the correct ref.
+			break
+		} else {
+			// Return an error if the commit was not found
+			return nil, fmt.Errorf("commit with ref '%s' does not exist", commitRef)
 		}
 	}
 
-	// Return an error if the commit was not found
-	return nil, fmt.Errorf("commit with ref '%s' does not exist", commitRef)
+	for _, l := range query.Repository.PullRequest.Labels.Nodes {
+		pullRequest.Labels = append(pullRequest.Labels, l.LabelObject)
+	}
+
+	return &pullRequest, nil
 }
 
 // UpdateCommitStatus for a given commit (not supported by V4 API).

--- a/in.go
+++ b/in.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 // Get (business logic)
@@ -74,6 +75,12 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 	metadata.Add("message", pull.Tip.Message)
 	metadata.Add("author", pull.Tip.Author.User.Login)
 	metadata.Add("author_email", pull.Tip.Author.Email)
+
+	labels := []string{}
+	for _, label := range pull.Labels {
+		labels = append(labels, label.Name)
+	}
+	metadata.Add("labels", strings.Join(labels, ","))
 
 	// Write version and metadata for reuse in PUT
 	path := filepath.Join(outputDir, ".git", "resource")

--- a/in_test.go
+++ b/in_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestGet(t *testing.T) {
+	prLabels := []string{"label 1", "label 2"}
 
 	tests := []struct {
 		description    string
@@ -40,9 +41,9 @@ func TestGet(t *testing.T) {
 				CommittedDate: time.Time{},
 			},
 			parameters:     resource.GetParameters{},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
+			pullRequest:    createTestPR(1, "master", false, false, 0, prLabels),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"labels","value":"label 1,label 2"}]`,
 		},
 		{
 			description: "get supports unlocking with git crypt",
@@ -57,9 +58,9 @@ func TestGet(t *testing.T) {
 				CommittedDate: time.Time{},
 			},
 			parameters:     resource.GetParameters{},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
+			pullRequest:    createTestPR(1, "master", false, false, 0, prLabels),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"labels","value":"label 1,label 2"}]`,
 		},
 		{
 			description: "get supports rebasing",
@@ -75,9 +76,9 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				IntegrationTool: "rebase",
 			},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
+			pullRequest:    createTestPR(1, "master", false, false, 0, prLabels),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"labels","value":"label 1,label 2"}]`,
 		},
 		{
 			description: "get supports checkout",
@@ -93,9 +94,9 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				IntegrationTool: "checkout",
 			},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
+			pullRequest:    createTestPR(1, "master", false, false, 0, prLabels),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"labels","value":"label 1,label 2"}]`,
 		},
 		{
 			description: "get supports git_depth",
@@ -111,9 +112,9 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				GitDepth: 2,
 			},
-			pullRequest:    createTestPR(1, "master", false, false, 0, nil),
+			pullRequest:    createTestPR(1, "master", false, false, 0, prLabels),
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"labels","value":"label 1,label 2"}]`,
 		},
 		{
 			description: "get supports list_changed_files",
@@ -129,7 +130,7 @@ func TestGet(t *testing.T) {
 			parameters: resource.GetParameters{
 				ListChangedFiles: true,
 			},
-			pullRequest: createTestPR(1, "master", false, false, 0, nil),
+			pullRequest: createTestPR(1, "master", false, false, 0, prLabels),
 			files: []resource.ChangedFileObject{
 				{
 					Path: "README.md",
@@ -139,7 +140,7 @@ func TestGet(t *testing.T) {
 				},
 			},
 			versionString:  `{"pr":"pr1","commit":"commit1","committed":"0001-01-01T00:00:00Z"}`,
-			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"}]`,
+			metadataString: `[{"name":"pr","value":"1"},{"name":"title","value":"pr1 title"},{"name":"url","value":"pr1 url"},{"name":"head_name","value":"pr1"},{"name":"head_sha","value":"oid1"},{"name":"base_name","value":"master"},{"name":"base_sha","value":"sha"},{"name":"message","value":"commit message1"},{"name":"author","value":"login1"},{"name":"author_email","value":"user@example.com"},{"name":"labels","value":"label 1,label 2"}]`,
 			filesString:    "README.md\nOther.md\n",
 		},
 	}
@@ -185,6 +186,7 @@ func TestGet(t *testing.T) {
 					"author":       "login1",
 					"author_email": "user@example.com",
 					"title":        "pr1 title",
+					"labels":       "label 1,label 2",
 				}
 
 				for filename, expected := range files {


### PR DESCRIPTION
This commit updates the `GetPullRequest` func to load the `labels` attached to the PR.
Also populate `metadata` with a comma separated list of labels.